### PR TITLE
 Implement join of Dict{Symbol,DataFrames}

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   - julia_version: nightly
 
 platform:
-  - x86 # 32-bit
   - x64 # 64-bit
 
 matrix:

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,6 +8,7 @@ Pages = ["api.md"]
 
 ```@docs
 format_table
+join
 latex_table
 markdown_table
 ```

--- a/src/SolverBenchmark.jl
+++ b/src/SolverBenchmark.jl
@@ -9,5 +9,6 @@ using DataFrames
 include("formatting.jl")
 include("latex_tables.jl")
 include("markdown_tables.jl")
+include("join.jl")
 
 end

--- a/src/join.jl
+++ b/src/join.jl
@@ -1,0 +1,62 @@
+import Base.join
+
+export join
+
+"""
+    df = join(stats, cols; kwargs...)
+
+Join a dictionary of DataFrames given by `stats`. Column `:id` is required in all
+DataFrames. The resulting DataFrame will have column `id` and all columns `cols` for
+each solver.
+
+Inputs:
+- `stats::Dict{Symbol,DataFrame}`: Dictionary of DataFrames per solver. Each key is a different solver;
+- `cols::Array{Symbol}`: Which columns of the DataFrames.
+
+Keyword arguments:
+- `invariant_cols::Array{Symbol,1}`: Invariant columns to be added, i.e., columns that don't change depending on the solver (such as name of problem, number of variables, etc.);
+- `hdr_override::Dict{Symbol,String}`: Override header names.
+
+Output:
+- `df::DataFrame`: Resulting dataframe.
+"""
+function join(stats::Dict{Symbol,DataFrame},
+              cols::Array{Symbol,1};
+              invariant_cols::Array{Symbol,1} = [],
+              hdr_override::Dict{Symbol,String} = Dict{Symbol,String}(),
+             )
+  length(cols) == 0 && error("cols can't be empty")
+  if !all(:id in names(df) for (s,df) in stats)
+    error("Missing column :id in some DataFrame")
+  elseif !all(setdiff(cols, names(df)) == [] for (s,df) in stats)
+    error("Not all DataFrames have all columns given by `cols`")
+  end
+
+  if :id in cols
+    deleteat!(cols, findall(cols .== :id))
+  end
+  if :id in invariant_cols
+    deleteat!(cols, findall(cols .== :id))
+  end
+  invariant_cols = [:id; invariant_cols]
+  cols = setdiff(cols, invariant_cols)
+  if length(cols) == 0
+    error("All columns are invariant")
+  end
+  cols = [:id; cols]
+
+  s = first(stats)[1]
+  df = stats[s][invariant_cols]
+
+  rename_f(c, s) = begin
+    c in invariant_cols && return c
+    sc = haskey(hdr_override, c) ? hdr_override[c] : string(c)
+    Symbol(sc * "_$s")
+  end
+
+  for (s, dfs) in stats
+    df = join(df, rename(c->rename_f(c, s), dfs[cols]), on=:id, makeunique=true)
+  end
+
+  return df
+end

--- a/test/example/alpha.md
+++ b/test/example/alpha.md
@@ -1,12 +1,12 @@
-|    flag |     f(x) |     time |  iter |
-|---------|----------|----------|-------|
-| failure | -6.9e-01 |  6.2e+01 |    70 |
-| failure | -7.6e-01 |  3.5e+02 |    10 |
-| success |  4.0e-01 |  7.7e+02 |    10 |
-| success |  8.1e-01 |  4.3e+01 |    80 |
-| success | -3.5e-01 |  2.7e+02 |    30 |
-| success | -1.9e-01 |  6.7e+01 |    80 |
-| success | -1.6e+00 |  1.6e+02 |    60 |
-| success | -2.5e+00 |  6.1e+02 |    40 |
-| success |  2.3e+00 |  1.4e+02 |    40 |
-| failure |  2.2e-01 |  8.4e+02 |    50 |
+|    flag |    name |     f(x) |     time |  iter |
+|---------|---------|----------|----------|-------|
+| failure | prob001 | -6.9e-01 |  6.2e+01 |    70 |
+| failure | prob002 | -7.6e-01 |  3.5e+02 |    10 |
+| success | prob003 |  4.0e-01 |  7.7e+02 |    10 |
+| success | prob004 |  8.1e-01 |  4.3e+01 |    80 |
+| success | prob005 | -3.5e-01 |  2.7e+02 |    30 |
+| success | prob006 | -1.9e-01 |  6.7e+01 |    80 |
+| success | prob007 | -1.6e+00 |  1.6e+02 |    60 |
+| success | prob008 | -2.5e+00 |  6.1e+02 |    40 |
+| success | prob009 |  2.3e+00 |  1.4e+02 |    40 |
+| failure | prob010 |  2.2e-01 |  8.4e+02 |    50 |

--- a/test/example/alpha.tex
+++ b/test/example/alpha.tex
@@ -1,29 +1,29 @@
-\begin{longtable}[c]{lrrr}
+\begin{longtable}[c]{lrrrr}
 \hline 
-flag & \(f(x)\) & time & iter \\
+flag & name & \(f(x)\) & time & iter \\
 \hline 
 \endfirsthead
-\multicolumn{4}{l}
+\multicolumn{5}{l}
 {{\bfseries \tablename\ \thetable{} --- continued from previous page}} \\
 \hline 
-flag & \(f(x)\) & time & iter \\
+flag & name & \(f(x)\) & time & iter \\
 \hline 
 \endhead
 \hline 
-\multicolumn{4}{r}{{\bfseries Continued on next page}} \\
+\multicolumn{5}{r}{{\bfseries Continued on next page}} \\
 \hline 
 \endfoot
 \hline 
 \endlastfoot
-failure & \(-6.9\)e\(-01\) & \( 6.2\)e\(+01\) & \(   70\) \\
-failure & \(-7.6\)e\(-01\) & \( 3.5\)e\(+02\) & \(   10\) \\
-success & \( 4.0\)e\(-01\) & \( 7.7\)e\(+02\) & \(   10\) \\
-success & \( 8.1\)e\(-01\) & \( 4.3\)e\(+01\) & \(   80\) \\
-success & \(-3.5\)e\(-01\) & \( 2.7\)e\(+02\) & \(   30\) \\
-success & \(-1.9\)e\(-01\) & \( 6.7\)e\(+01\) & \(   80\) \\
-success & \(-1.6\)e\(+00\) & \( 1.6\)e\(+02\) & \(   60\) \\
-success & \(-2.5\)e\(+00\) & \( 6.1\)e\(+02\) & \(   40\) \\
-success & \( 2.3\)e\(+00\) & \( 1.4\)e\(+02\) & \(   40\) \\
-failure & \( 2.2\)e\(-01\) & \( 8.4\)e\(+02\) & \(   50\) \\
+failure & prob001 & \(-6.9\)e\(-01\) & \( 6.2\)e\(+01\) & \(   70\) \\
+failure & prob002 & \(-7.6\)e\(-01\) & \( 3.5\)e\(+02\) & \(   10\) \\
+success & prob003 & \( 4.0\)e\(-01\) & \( 7.7\)e\(+02\) & \(   10\) \\
+success & prob004 & \( 8.1\)e\(-01\) & \( 4.3\)e\(+01\) & \(   80\) \\
+success & prob005 & \(-3.5\)e\(-01\) & \( 2.7\)e\(+02\) & \(   30\) \\
+success & prob006 & \(-1.9\)e\(-01\) & \( 6.7\)e\(+01\) & \(   80\) \\
+success & prob007 & \(-1.6\)e\(+00\) & \( 1.6\)e\(+02\) & \(   60\) \\
+success & prob008 & \(-2.5\)e\(+00\) & \( 6.1\)e\(+02\) & \(   40\) \\
+success & prob009 & \( 2.3\)e\(+00\) & \( 1.4\)e\(+02\) & \(   40\) \\
+failure & prob010 & \( 2.2\)e\(-01\) & \( 8.4\)e\(+02\) & \(   50\) \\
 \hline 
 \end{longtable}

--- a/test/example/joined.md
+++ b/test/example/joined.md
@@ -1,0 +1,12 @@
+|    id |    name | flag_alpha |  f_alpha |  t_alpha | flag_beta |   f_beta |   t_beta | flag_gamma |  f_gamma |  t_gamma |
+|-------|---------|------------|----------|----------|-----------|----------|----------|------------|----------|----------|
+|     1 | prob001 |    failure | -6.9e-01 |  6.2e+01 |   success | -1.1e+00 |  1.8e+02 |    success |  6.3e-02 |  3.3e+01 |
+|     2 | prob002 |    failure | -7.6e-01 |  3.5e+02 |   failure |  8.2e-01 |  8.0e+01 |    success |  1.2e-01 |  6.9e+02 |
+|     3 | prob003 |    success |  4.0e-01 |  7.7e+02 |   success |  1.5e-01 |  6.8e+02 |    success |  2.7e+00 |  8.4e+02 |
+|     4 | prob004 |    success |  8.1e-01 |  4.3e+01 |   failure | -3.3e-01 |  9.3e+02 |    failure | -6.9e-01 |  1.9e+02 |
+|     5 | prob005 |    success | -3.5e-01 |  2.7e+02 |   failure |  1.4e+00 |  9.7e+02 |    failure | -5.5e-02 |  1.6e+02 |
+|     6 | prob006 |    success | -1.9e-01 |  6.7e+01 |   success | -4.4e-01 |  6.5e+02 |    success |  4.2e-01 |  9.0e+02 |
+|     7 | prob007 |    success | -1.6e+00 |  1.6e+02 |   success |  1.1e+00 |  6.0e+02 |    success | -1.4e+00 |  9.5e+01 |
+|     8 | prob008 |    success | -2.5e+00 |  6.1e+02 |   success | -2.5e-01 |  4.8e+02 |    failure | -4.5e-01 |  7.8e+02 |
+|     9 | prob009 |    success |  2.3e+00 |  1.4e+02 |   failure |  2.9e-01 |  6.3e+01 |    failure | -8.8e-01 |  8.7e+02 |
+|    10 | prob010 |    failure |  2.2e-01 |  8.4e+02 |   success | -3.5e+00 |  4.7e+02 |    success |  1.1e+00 |  8.4e+02 |

--- a/test/example/joined.tex
+++ b/test/example/joined.tex
@@ -1,0 +1,29 @@
+\begin{longtable}[c]{lrrrrrrrrrr}
+\hline 
+id & name & flag\_alpha & f\_alpha & t\_alpha & flag\_beta & f\_beta & t\_beta & flag\_gamma & f\_gamma & t\_gamma \\
+\hline 
+\endfirsthead
+\multicolumn{11}{l}
+{{\bfseries \tablename\ \thetable{} --- continued from previous page}} \\
+\hline 
+id & name & flag\_alpha & f\_alpha & t\_alpha & flag\_beta & f\_beta & t\_beta & flag\_gamma & f\_gamma & t\_gamma \\
+\hline 
+\endhead
+\hline 
+\multicolumn{11}{r}{{\bfseries Continued on next page}} \\
+\hline 
+\endfoot
+\hline 
+\endlastfoot
+\(    1\) & prob001 & failure & \(-6.9\)e\(-01\) & \( 6.2\)e\(+01\) & success & \(-1.1\)e\(+00\) & \( 1.8\)e\(+02\) & success & \( 6.3\)e\(-02\) & \( 3.3\)e\(+01\) \\
+\(    2\) & prob002 & failure & \(-7.6\)e\(-01\) & \( 3.5\)e\(+02\) & failure & \( 8.2\)e\(-01\) & \( 8.0\)e\(+01\) & success & \( 1.2\)e\(-01\) & \( 6.9\)e\(+02\) \\
+\(    3\) & prob003 & success & \( 4.0\)e\(-01\) & \( 7.7\)e\(+02\) & success & \( 1.5\)e\(-01\) & \( 6.8\)e\(+02\) & success & \( 2.7\)e\(+00\) & \( 8.4\)e\(+02\) \\
+\(    4\) & prob004 & success & \( 8.1\)e\(-01\) & \( 4.3\)e\(+01\) & failure & \(-3.3\)e\(-01\) & \( 9.3\)e\(+02\) & failure & \(-6.9\)e\(-01\) & \( 1.9\)e\(+02\) \\
+\(    5\) & prob005 & success & \(-3.5\)e\(-01\) & \( 2.7\)e\(+02\) & failure & \( 1.4\)e\(+00\) & \( 9.7\)e\(+02\) & failure & \(-5.5\)e\(-02\) & \( 1.6\)e\(+02\) \\
+\(    6\) & prob006 & success & \(-1.9\)e\(-01\) & \( 6.7\)e\(+01\) & success & \(-4.4\)e\(-01\) & \( 6.5\)e\(+02\) & success & \( 4.2\)e\(-01\) & \( 9.0\)e\(+02\) \\
+\(    7\) & prob007 & success & \(-1.6\)e\(+00\) & \( 1.6\)e\(+02\) & success & \( 1.1\)e\(+00\) & \( 6.0\)e\(+02\) & success & \(-1.4\)e\(+00\) & \( 9.5\)e\(+01\) \\
+\(    8\) & prob008 & success & \(-2.5\)e\(+00\) & \( 6.1\)e\(+02\) & success & \(-2.5\)e\(-01\) & \( 4.8\)e\(+02\) & failure & \(-4.5\)e\(-01\) & \( 7.8\)e\(+02\) \\
+\(    9\) & prob009 & success & \( 2.3\)e\(+00\) & \( 1.4\)e\(+02\) & failure & \( 2.9\)e\(-01\) & \( 6.3\)e\(+01\) & failure & \(-8.8\)e\(-01\) & \( 8.7\)e\(+02\) \\
+\(   10\) & prob010 & failure & \( 2.2\)e\(-01\) & \( 8.4\)e\(+02\) & success & \(-3.5\)e\(+00\) & \( 4.7\)e\(+02\) & success & \( 1.1\)e\(+00\) & \( 8.4\)e\(+02\) \\
+\hline 
+\end{longtable}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 # stdlib imports
-using Random, Test
+using Printf, Random, Test
 
 # dependencies imports
 using DataFrames

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -1,11 +1,11 @@
 # Test all table output
 function test_tables()
   example_folder = joinpath(@__DIR__, "example")
-  println(example_folder)
   Random.seed!(0)
   n = 10
   names = [:alpha, :beta, :gamma]
   stats = Dict(name => DataFrame(:id => 1:n,
+                                 :name => [@sprintf("prob%03d", i) for i = 1:n],
                                  :status => map(x -> x ? :success : :failure, rand(n) .< 0.75),
                                  :f => randn(n),
                                  :t => 1e-3 .+ rand(n) * 1000,
@@ -14,7 +14,7 @@ function test_tables()
 
   @info "Show all table output for single solver"
   df = stats[:alpha]
-  cols = [:status, :f, :t, :iter]
+  cols = [:status, :name, :f, :t, :iter]
 
   @info "alpha results in DataFrame format"
   println(df[cols])
@@ -36,6 +36,31 @@ function test_tables()
     markdown_table(io, df, cols=cols, hdr_override=header)
   end
   new_lines = readlines("$example_folder/alpha.md", keep=true)
+  println(join(new_lines))
+  @test old_lines == new_lines
+
+  @info "Show all table output for joined solver"
+  df = join(stats, [:status, :f, :t], invariant_cols=[:name],
+            hdr_override=Dict(:status => "flag"))
+
+  @info "joined results in DataFrame format"
+  println(df)
+
+  @info "joined results in latex format"
+  old_lines = readlines("$example_folder/joined.tex", keep=true)
+  open("$example_folder/joined.tex", "w") do io
+    latex_table(io, df)
+  end
+  new_lines = readlines("$example_folder/joined.tex", keep=true)
+  println(join(new_lines))
+  @test old_lines == new_lines
+
+  @info "joined results in markdown format"
+  old_lines = readlines("$example_folder/joined.md", keep=true)
+  open("$example_folder/joined.md", "w") do io
+    markdown_table(io, df)
+  end
+  new_lines = readlines("$example_folder/joined.md", keep=true)
   println(join(new_lines))
   @test old_lines == new_lines
 end


### PR DESCRIPTION
Built on top of #3, needs rebase after.

Implements `join(stats, cols)` where `stats` is a dictionary `:solver => df` and `cols` are which columns to join`. Joins on `:id` column, and accepts additional invariant columns, such as `name`, `nvar`, `ncon`, etc.