### PR TITLE
Solve a bug in to_gist function

### DIFF
--- a/src/pkgbmark.jl
+++ b/src/pkgbmark.jl
@@ -127,7 +127,7 @@ function to_gist(results::PkgBenchmark.BenchmarkResults, p)
     "public": true,
     "files": {
         "bmark.md": {
-          "content": "$(escape_string(sprint(PkgBenchmark.export_markdown, stdout, results)))"
+          "content": "$(escape_string(sprint(PkgBenchmark.export_markdown, results; context=stdout)))"
         },
         "bmark.svg": {
           "content": "$(svgfilecontents)"

--- a/src/pkgbmark.jl
+++ b/src/pkgbmark.jl
@@ -126,8 +126,8 @@ function to_gist(results::PkgBenchmark.BenchmarkResults, p)
     "description": "A benchmark for Krylov repository",
     "public": true,
     "files": {
-        "bmark.md.md": {
-          "content": "$(escape_string(sprint(export_markdown, stdout, results)))"
+        "bmark.md": {
+          "content": "$(escape_string(sprint(PkgBenchmark.export_markdown, stdout, results)))"
         },
         "bmark.svg": {
           "content": "$(svgfilecontents)"

--- a/src/pkgbmark.jl
+++ b/src/pkgbmark.jl
@@ -123,7 +123,7 @@ function to_gist(results::PkgBenchmark.BenchmarkResults, p)
   gist_json = JSON.parse(
   """
   {
-    "description": "A benchmark for Krylov repository",
+    "description": "Benchmarks uploaded by SolverBenchmark.jl",
     "public": true,
     "files": {
         "bmark.md": {


### PR DESCRIPTION
PkgBenchmark package is only imported in pkgbmark.jl.
The function `to_gist` is unable to find `export_markdown`.

PS : Maybe we should do a new release of this package?
There is only one release, done in march 2019.