### PR TITLE
highlight failures in markdown tables

### DIFF
--- a/src/SolverBenchmark.jl
+++ b/src/SolverBenchmark.jl
@@ -5,6 +5,7 @@ using Printf
 
 # dependencies imports
 using DataFrames
+using PrettyTables
 
 # Tables
 include("formatting.jl")

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -43,10 +43,19 @@ function format_table(df :: DataFrame, formatter::Function;
     @error("There are no columns `" * join(missing_cols, ", ") * "` in dataframe")
     throw(BoundsError)
   end
+  local hl
+  if hasproperty(df, :status)
+    # extract failure ids
+    failure_id = df[(df.status .!= :first_order) .& (df.status .!= :unbounded), :].id
+    hl = Highlighter(f = (data, i, j) -> i ∈ failure_id, crayon = crayon"bold red")
+  else
+    hl = Highlighter(f = (data, i, j) -> false, crayon = crayon"black")
+  end
+
   string_cols = [map(haskey(fmt_override, col) ? fmt_override[col] : formatter, df[!, col]) for col in cols]
   table = hcat(string_cols...)
 
   header = [haskey(hdr_override, c) ? hdr_override[c] : formatter(c) for c in cols]
 
-  return header, table
+  return header, table, hl
 end

--- a/src/latex_tables.jl
+++ b/src/latex_tables.jl
@@ -87,7 +87,7 @@ We recommend using the `safe_latex_foo` functions when overriding formats, unles
 you're sure you don't need them.
 """
 function latex_table(io :: IO, df :: DataFrame; kwargs...)
-  header, table = format_table(df, LTXformat; kwargs...)
+  header, table, _ = format_table(df, LTXformat; kwargs...)  # ignore highlighter
   latex_tabular(io, LongTable("l" * "r"^(length(header)-1), header),
                 [table, Rule()])
   nothing

--- a/src/markdown_tables.jl
+++ b/src/markdown_tables.jl
@@ -1,5 +1,3 @@
-using PrettyTables
-
 export MDformat, markdown_table
 
 for (typ, fmt) in formats
@@ -49,8 +47,8 @@ Keyword arguments:
 - `hdr_override::Dict{Symbol,String}`: Overrides header names, such as `hdr_override=Dict(:name => "Name")`.
 """
 function markdown_table(io :: IO, df :: DataFrame; kwargs...)
-  header, table = format_table(df, MDformat; kwargs...)
-  pretty_table(io, table, header, markdown)
+  header, table, hl = format_table(df, MDformat; kwargs...)
+  pretty_table(io, table, header, tf=markdown, highlighters=hl)
   nothing
 end
 


### PR DESCRIPTION
These changes automatically highlight failures (in bold red) when producing a Markdown table.

Example:
![Screen Shot 2019-12-17 at 14 21 28](https://user-images.githubusercontent.com/38760/71027155-b0d51200-20d8-11ea-9c1c-9f663bc97ee7.png)
(this commit also makes the warning disappear)

Because highlighting is based on the status found in the DataFrame, it works even if `:status` isn't part of the columns in the final table:
![Screen Shot 2019-12-17 at 14 21 38](https://user-images.githubusercontent.com/38760/71027114-969b3400-20d8-11ea-9187-9509bf34f10c.png)

In the future, it could be interesting to generalize this idea in several ways:
* highlight similar statuses (not just failures);
* explore PrettyTable's recent LaTeX export feature and see if highlighters and crayons carry over to the LaTeX code somehow.