### PR TITLE
Bump NLPModels to 0.15 and co

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,11 +32,11 @@ GitHub = "^5.0.2"
 JLD2 = "0.1.12, 0.2, 0.3, 0.4"
 JSON = "0.20.0, 0.21.0"
 LaTeXTabulars = "^0.1.0"
-NLPModels = "0.14"
+NLPModels = "0.14, 0.15"
 PkgBenchmark = "^0.2.0"
 Plots = "1.0, 1.1"
 PrettyTables = "0.12, 1.0"
-SolverCore = "0.1"
+SolverCore = "0.1, 0.2"
 julia = "^1.3.0"
 
 [extras]


### PR DESCRIPTION
Follows [NLPModels.jl PR #353](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/353) with parametric meta.