### PR TITLE
Avoid `AbstractVector` in `stats.solver_specific`

### DIFF
--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -65,8 +65,10 @@ function solve_problems(solver, problems;
         end
         if first_problem
           for (k,v) in s.solver_specific
-            insertcols!(stats, ncol(stats)+1, k => Vector{Union{typeof(v),Missing}}())
-            push!(specific, k)
+            #if !(typeof(v) <: AbstractVector)
+              insertcols!(stats, ncol(stats)+1, k => Vector{Union{typeof(v),Missing}}())
+              push!(specific, k)
+            #end
           end
 
           @info log_header(colstats, types[col_idx], hdr_override=info_hdr_override)

--- a/test/dummy_solver.jl
+++ b/test/dummy_solver.jl
@@ -66,6 +66,7 @@ function dummy_solver(nlp :: AbstractNLPModel;
   return GenericExecutionStats(:unknown, nlp,
                                objective=fx, dual_feas=norm(dual), primal_feas=norm(cx),
                                multipliers=y, multipliers_L=zeros(T, nvar), multipliers_U=zeros(T, nvar),
-                               elapsed_time=elapsed_time, solution=x, iter=iter
+                               elapsed_time=elapsed_time, solution=x, iter=iter,
+                               solver_specific = Dict(:multiplier => y)
                               )
 end

--- a/test/test_bmark.jl
+++ b/test/test_bmark.jl
@@ -46,6 +46,8 @@ function test_bmark()
     end
 
     statuses, avgs = quick_summary(stats)
+    
+    pretty_stats(stats[:dummy])
   end
 
   @testset "Testing logging" begin


### PR DESCRIPTION
Connected to #101 , we do not keep `AbstractVector` from `stats.solver_specific` in the output of `solver_problems` (and therefore `bmark_solvers`)