### PR TITLE
Push other tags in documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+    tags: '*'
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
The build and deployment of documentation of stable versions have been failing for a while (only version 0.3.1 is shown).
This is an attempt to fix it.