### PR TITLE
Fix string15 supertype

### DIFF
--- a/src/formats.jl
+++ b/src/formats.jl
@@ -6,7 +6,6 @@ const default_formatters =
 abstract_supertype(T::DataType) = T == Symbol ? T : supertype(T)
 abstract_supertype(::Type{<:AbstractFloat}) = AbstractFloat
 abstract_supertype(::Type{<:AbstractString}) = AbstractString
-# abstract_supertype(String15) = AbstractString but supertype(String15) = InlineString
 
 """
     pretty_stats(df; kwargs...)

--- a/src/formats.jl
+++ b/src/formats.jl
@@ -3,6 +3,11 @@ export pretty_stats
 const default_formatters =
   Dict(AbstractFloat => "%9.2e", Signed => "%6d", AbstractString => "%15s", Symbol => "%15s")
 
+abstract_supertype(T::DataType) = T == Symbol ? T : supertype(T)
+abstract_supertype(::Type{<:AbstractFloat}) = AbstractFloat
+abstract_supertype(::Type{<:AbstractString}) = AbstractString
+# abstract_supertype(String15) = AbstractString but supertype(String15) = InlineString
+
 """
     pretty_stats(df; kwargs...)
 
@@ -62,8 +67,8 @@ function pretty_stats(
       push!(pt_formatters, ft_printf(col_formatters[name], col))
     else
       typ = Missings.nonmissingtype(eltype(df[!, name]))
-      styp = supertype(typ)
-      push!(pt_formatters, ft_printf(default_formatters[typ == Symbol ? typ : styp], col))
+      used_format_type = abstract_supertype(typ)
+      push!(pt_formatters, ft_printf(default_formatters[used_format_type], col))
     end
   end
 

--- a/src/latex_formats.jl
+++ b/src/latex_formats.jl
@@ -147,9 +147,10 @@ function pretty_latex_stats(
       push!(pt_formatters, ft_printf(col_formatters[name], col))
     else
       # be careful because supertype(Symbol) = Any
-      push!(pt_formatters, ft_printf(default_formatters[typ == Symbol ? typ : styp], col))
+      used_format_type = abstract_supertype(typ)
+      push!(pt_formatters, ft_printf(default_formatters[used_format_type], col))
       # add LaTeX-specific formatters to make our table pretty
-      push!(pt_formatters, safe_latex_formatters[typ == Symbol ? typ : styp](col))
+      push!(pt_formatters, safe_latex_formatters[used_format_type](col))
     end
   end
 


### PR DESCRIPTION
When using `solve_problems` and saving my results to a CSV file with CSV.jl, I generate a `String15 <: InlineString <: AbstractString` column for the problem names. Since `supertype(String15) = InlineString` which is not in `default_formatters`, I made the changes in this PR so that the formatter of a `String15` is `"%15s"`.

If you do not like this change, I can also set manually `SolverBenchmark.default_formatters[InlineString] = "%15s"` everytime and close this PR.