### PR TITLE
bump version to 0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SolverBenchmark"
 uuid = "581a75fa-a23a-52d0-a590-d6201de2218a"
-version = "0.5.5"
+version = "0.6.0"
 
 [deps]
 BenchmarkProfiles = "ecbce9bc-3e5e-569d-9e29-55181f61f8d0"


### PR DESCRIPTION
Bumping to 0.6 because the metadata of the DataFrame format changed after 1.4. That causes recent versions of JLD2 to be unable to load the old format properly.