### PR TITLE
Solver name added after the info, and iteration counts are also added

### DIFF
--- a/src/bmark_solvers.jl
+++ b/src/bmark_solvers.jl
@@ -19,7 +19,7 @@ function bmark_solvers(solvers::Dict{Symbol, <:Any}, args...; kwargs...)
   stats = Dict{Symbol, DataFrame}()
   for (name, solver) in solvers
     @info "running solver $name"
-    stats[name] = solve_problems(solver, args...; kwargs...)
+    stats[name] = solve_problems(solver, "$name", args...; kwargs...)
   end
   return stats
 end

--- a/src/bmark_solvers.jl
+++ b/src/bmark_solvers.jl
@@ -19,7 +19,7 @@ function bmark_solvers(solvers::Dict{Symbol, <:Any}, args...; kwargs...)
   stats = Dict{Symbol, DataFrame}()
   for (name, solver) in solvers
     @info "running solver $name"
-    stats[name] = solve_problems(solver, "$name", args...; kwargs...)
+    stats[name] = solve_problems(solver, name, args...; kwargs...)
   end
   return stats
 end

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -126,7 +126,7 @@ function solve_problems(
             end
           end
 
-          @info  solver_name * " " *  log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
+          @info  "Solver"    * " " *  log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
 
           first_problem = false
         end

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -1,12 +1,13 @@
 export solve_problems
 
 """
-    solve_problems(solver, problems; kwargs...)
+    solve_problems(solver, solver_name, problems; kwargs...)
 
 Apply a solver to a set of problems.
 
 #### Arguments
 * `solver`: the function name of a solver;
+* `solver_name`: name of the solver;
 * `problems`: the set of problems to pass to the solver, as an iterable of
   `AbstractNLPModel`. It is recommended to use a generator expression (necessary for
   CUTEst problems).

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -174,7 +174,7 @@ function solve_problems(
         finalize(problem)
       end
     end
-    (skipthis && prune) || @info solver_name * " " *   log_row(stats[end, col_idx])
+    (skipthis && prune) || @info solver_name * " " * log_row(stats[end, col_idx])
   end
   return stats
 end

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -174,7 +174,7 @@ function solve_problems(
         finalize(problem)
       end
     end
-    (skipthis && prune) || @info solver_name * "\$ " *   log_row(stats[end, col_idx])
+    (skipthis && prune) || @info solver_name * " " *   log_row(stats[end, col_idx])
   end
   return stats
 end

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -29,12 +29,13 @@ benchmark (default: `[:name, :nvar, :ncon, :status, :elapsed_time, :objective, :
 """
 function solve_problems(
   solver,
-  solver_name,
+  solver_name::TName,
   problems;
   solver_logger::AbstractLogger = NullLogger(),
   reset_problem::Bool = true,
   skipif::Function = x -> false,
   colstats::Vector{Symbol} = [
+    :solver_name,
     :name,
     :nvar,
     :ncon,
@@ -45,14 +46,15 @@ function solve_problems(
     :dual_feas,
     :primal_feas,
   ],
-  info_hdr_override::Dict{Symbol, String} = Dict{Symbol, String}(),
+  info_hdr_override::Dict{Symbol, String} = Dict{Symbol, String}(:solver_name => "Solver"),
   prune::Bool = true,
   kwargs...,
-)
+) where {TName}
   f_counters = collect(fieldnames(Counters))
   fnls_counters = collect(fieldnames(NLSCounters))[2:end] # Excludes :counters
   ncounters = length(f_counters) + length(fnls_counters)
   types = [
+    TName
     Int
     String
     Int
@@ -68,6 +70,7 @@ function solve_problems(
     String
   ]
   names = [
+    :solver_name
     :id
     :name
     :nvar
@@ -101,6 +104,7 @@ function solve_problems(
       prune || push!(
         stats,
         [
+          solver_name
           problem_info
           :exception
           Inf
@@ -127,7 +131,7 @@ function solve_problems(
             end
           end
 
-          @info solver_name * " " * log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
+          @info log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
 
           first_problem = false
         end
@@ -141,6 +145,7 @@ function solve_problems(
         push!(
           stats,
           [
+            solver_name
             problem_info
             s.status
             s.objective
@@ -159,6 +164,7 @@ function solve_problems(
         push!(
           stats,
           [
+            solver_name
             problem_info
             :exception
             Inf
@@ -175,7 +181,7 @@ function solve_problems(
         finalize(problem)
       end
     end
-    (skipthis && prune) || @info solver_name * " " * log_row(stats[end, col_idx])
+    (skipthis && prune) || @info log_row(stats[end, col_idx])
   end
   return stats
 end

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -28,6 +28,7 @@ benchmark (default: `[:name, :nvar, :ncon, :status, :elapsed_time, :objective, :
 """
 function solve_problems(
   solver,
+  solver_name,
   problems;
   solver_logger::AbstractLogger = NullLogger(),
   reset_problem::Bool = true,
@@ -37,6 +38,7 @@ function solve_problems(
     :nvar,
     :ncon,
     :status,
+    :iter,
     :elapsed_time,
     :objective,
     :dual_feas,
@@ -124,7 +126,7 @@ function solve_problems(
             end
           end
 
-          @info log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
+          @info  log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
 
           first_problem = false
         end
@@ -172,7 +174,7 @@ function solve_problems(
         finalize(problem)
       end
     end
-    (skipthis && prune) || @info log_row(stats[end, col_idx])
+    (skipthis && prune) || @info solver_name * "$ " *   log_row(stats[end, col_idx])
   end
   return stats
 end

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -126,7 +126,7 @@ function solve_problems(
             end
           end
 
-          @info  "Solver"    * " " *  log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
+          @info solver_name * " " * log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
 
           first_problem = false
         end

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -126,7 +126,7 @@ function solve_problems(
             end
           end
 
-          @info  log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
+          @info  solver_name * " " *  log_header(colstats, types[col_idx], hdr_override = info_hdr_override)
 
           first_problem = false
         end

--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -174,7 +174,7 @@ function solve_problems(
         finalize(problem)
       end
     end
-    (skipthis && prune) || @info solver_name * "$ " *   log_row(stats[end, col_idx])
+    (skipthis && prune) || @info solver_name * "\$ " *   log_row(stats[end, col_idx])
   end
   return stats
 end

--- a/test/test_bmark.jl
+++ b/test/test_bmark.jl
@@ -33,12 +33,12 @@ function test_bmark()
       ),
     ]
     callable = CallableSolver()
-    stats = solve_problems(dummy_solver, problems)
+    stats = solve_problems(dummy_solver, "dummy", problems)
     @test stats isa DataFrame
-    stats = solve_problems(dummy_solver, problems, reset_problem = false)
-    stats = solve_problems(dummy_solver, problems, reset_problem = true)
+    stats = solve_problems(dummy_solver, "dummy", problems, reset_problem = false)
+    stats = solve_problems(dummy_solver, "dummy", problems, reset_problem = true)
 
-    solve_problems(callable, problems)
+    solve_problems(callable, "callable", problems)
 
     solvers = Dict(:dummy => dummy_solver, :callable => callable)
     stats = bmark_solvers(solvers, problems)
@@ -73,12 +73,13 @@ function test_bmark()
     )
     with_logger(ConsoleLogger()) do
       @info "Testing simple logger on `solve_problems`"
-      solve_problems(dummy_solver, nlps)
+      solve_problems(dummy_solver, "dummy", nlps)
       reset!.(nlps)
 
       @info "Testing logger with specific columns on `solve_problems`"
       solve_problems(
         dummy_solver,
+        "dummy",
         nlps,
         colstats = [:name, :nvar, :elapsed_time, :objective, :dual_feas],
       )
@@ -86,7 +87,7 @@ function test_bmark()
 
       @info "Testing logger with hdr_override on `solve_problems`"
       hdr_override = Dict(:dual_feas => "‖∇L(x)‖", :primal_feas => "‖c(x)‖")
-      solve_problems(dummy_solver, nlps, info_hdr_override = hdr_override)
+      solve_problems(dummy_solver, "dummy", nlps, info_hdr_override = hdr_override)
       reset!.(nlps)
     end
   end


### PR DESCRIPTION
Hi there,
with your latest crystal clear instructions I managed it. Please let me know if you are happy with the result. I used the dollar $ after the solver name as reminiscent of the Linux Bash-shell prompt. We could change it to any other fancy Unicode character. I have also additional suggestions to make about output of benchmark solvers. It seems that the CUTEst database and/or the OptimizationProblems.meta problems have info which is not clear what it stands for. Lets discuss on another thread.