### PR TITLE
allow AbstractDict in profiles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -51,6 +51,7 @@ BenchmarkProfiles = "ecbce9bc-3e5e-569d-9e29-55181f61f8d0"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PGFPlotsX = "8314cec4-20b6-5062-9cdb-752b83310925"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -60,4 +61,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["ADNLPModels", "BenchmarkProfiles", "LibGit2", "LinearAlgebra", "NLPModels", "Test", "Plots", "Random", "PGFPlotsX", "Printf", "UnicodePlots", "SparseArrays"]
+test = ["ADNLPModels", "BenchmarkProfiles", "LibGit2", "LinearAlgebra", "NLPModels", "OrderedCollections", "Test", "Plots", "Random", "PGFPlotsX", "Printf", "UnicodePlots", "SparseArrays"]

--- a/src/join.jl
+++ b/src/join.jl
@@ -10,21 +10,21 @@ DataFrames. The resulting DataFrame will have column `id` and all columns `cols`
 each solver.
 
 Inputs:
-- `stats::Dict{Symbol,DataFrame}`: Dictionary of DataFrames per solver. Each key is a different solver;
+- `stats::AbstractDict{Symbol,DataFrame}`: Dictionary of DataFrames per solver. Each key is a different solver;
 - `cols::Array{Symbol}`: Which columns of the DataFrames.
 
 Keyword arguments:
 - `invariant_cols::Array{Symbol,1}`: Invariant columns to be added, i.e., columns that don't change depending on the solver (such as name of problem, number of variables, etc.);
-- `hdr_override::Dict{Symbol,String}`: Override header names.
+- `hdr_override::AbstractDict{Symbol,String}`: Override header names.
 
 Output:
 - `df::DataFrame`: Resulting dataframe.
 """
 function join(
-  stats::Dict{Symbol, DataFrame},
+  stats::AbstractDict{Symbol, DataFrame},
   cols::Array{Symbol, 1};
   invariant_cols::Array{Symbol, 1} = Symbol[],
-  hdr_override::Dict{Symbol, String} = Dict{Symbol, String}(),
+  hdr_override::AbstractDict{Symbol, String} = Dict{Symbol, String}(),
 )
   length(cols) == 0 && error("cols can't be empty")
   if !all(:id in propertynames(df) for (s, df) in stats)

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -9,18 +9,21 @@ export performance_profile, profile_solvers
 Produce a performance profile comparing solvers in `stats` using the `cost` function.
 
 Inputs:
-- `stats::Dict{Symbol,DataFrame}`: pairs of `:solver => df`;
+- `stats::AbstractDict{Symbol,DataFrame}`: pairs of `:solver => df`;
 - `cost::Function`: cost function applyed to each `df`. Should return a vector with the cost of solving the problem at each row;
   - 0 cost is not allowed;
   - If the solver did not solve the problem, return Inf or a negative number.
 - `b::BenchmarkProfiles.AbstractBackend` : backend used for the plot.
+
+If several profiles will be produced with variants of the same solvers, `stats` may be an `OrderedDict`, as defined in the
+OrderedCollections.jl package.
 
 Examples of cost functions:
 - `cost(df) = df.elapsed_time`: Simple `elapsed_time` cost. Assumes the solver solved the problem.
 - `cost(df) = (df.status .!= :first_order) * Inf + df.elapsed_time`: Takes into consideration the status of the solver.
 """
 function performance_profile(
-  stats::Dict{Symbol, DataFrame},
+  stats::AbstractDict{Symbol, DataFrame},
   cost::Function,
   args...;
   b::BenchmarkProfiles.AbstractBackend = PlotsBackend(),
@@ -40,7 +43,7 @@ end
 Produce performance profiles comparing `solvers` based on the data in `stats`.
 
 Inputs:
-- `stats::Dict{Symbol,DataFrame}`: a dictionary of `DataFrame`s containing the
+- `stats::AbstractDict{Symbol,DataFrame}`: a dictionary of `DataFrame`s containing the
     benchmark results per solver (e.g., produced by `bmark_results_to_dataframes()`)
 - `costs::Vector{Function}`: a vector of functions specifying the measures to use in the profiles
 - `costnames::Vector{String}`: names to be used as titles of the profiles.
@@ -60,7 +63,7 @@ If there are more than two solvers, additional profiles are produced comparing t
 solvers two by two on each cost measure.
 """
 function profile_solvers(
-  stats::Dict{Symbol, DataFrame},
+  stats::AbstractDict{Symbol, DataFrame},
   costs::Vector{<:Function},
   costnames::Vector{String};
   width::Int = 400,

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,7 +1,7 @@
 function get_stats_data()
   n = 10
   names = [:alpha, :beta, :gamma]
-  stats = Dict(
+  stats = OrderedDict(
     name => DataFrame(
       :id => 1:n,
       :name => [@sprintf("prob%03d", i) for i = 1:n],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using DataFrames
 using LaTeXStrings
 
 # test dependencies
+using OrderedCollections
 using PGFPlotsX
 using UnicodePlots
 using Plots


### PR DESCRIPTION
This change should allow uses to use an OrderedDict to store statistics, and have solvers use consistent colors in plots when producing several profiles with variants of the same solvers.