### PR TITLE
docs: document solver-specific statistics in solve_problems

### DIFF
--- a/src/run_solver.jl
+++ b/src/run_solver.jl
@@ -18,7 +18,7 @@ Apply a solver to a set of problems.
 * `skipif::Function`: function to be applied to a problem and return whether to skip it
   (default: `x->false`);
 * `colstats::Vector{Symbol}`: summary statistics for the logger to output during the
-benchmark (default: `[:name, :nvar, :ncon, :status, :elapsed_time, :objective, :dual_feas, :primal_feas]`). Solver's `solver_specific` scalar entries are appended as extra columns.
+benchmark (default: `[:name, :nvar, :ncon, :status, :elapsed_time, :objective, :dual_feas, :primal_feas]`), solver's `solver_specific` scalar entries are appended as extra columns;
 * `info_hdr_override::Dict{Symbol,String}`: header overrides for the summary statistics
   (default: use default headers);
 * `prune`: do not include skipped problems in the final statistics (default: `true`);


### PR DESCRIPTION
Added a "Solver-specific statistics" section to the solve_problems docstring in `run_solver.jl`. The new text explains how entries in s.solver_specific are handled:
- scalar (non-vector) entries become additional DataFrame columns;
- vector-valued entries are ignored for column creation;
- columns are created when the first successful run returns those keys;
- skipped or exception rows are filled with missing for solver-specific columns;
- how to set solver-specific values from a solver (e.g. via callbacks and set_solver_specific!), with tests/examples already exercising the behavior.

Fixes #152
